### PR TITLE
[fix] Prevent infinite loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# December 22, 2015 v0.5.1
+
+This release fixes the following situation.
+
+If an action were to take place during a `componentWillMount`, this
+will cause an infinite loop as the action triggers `combineLatest`
+to emit an event, which then triggers another `renderToString`
+which starts the whole thing over again.
+
+There is a `first` filter in the stream, but internally the `onNext` of
+the observer is called before the `onCompleted` of the observer can be
+called, meaning the `first` filter never has a chance to call `onCompleted`
+
+Moral of the story? Beware of Zalgo!
+
+* [08411fe](../../commit/08411fe) [fix] Prevent infinite loops
+
 # December 20, 2015 v0.5.0
 
 This release is a breaking change. It depends on internal API changes introduced

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thundercats-react",
   "description": "Thundercats addon for use with React",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "homepage": "http://thundercats.js.org",
   "keywords": [
     "alwaysUseTwoSpaces",

--- a/src/Render.js
+++ b/src/Render.js
@@ -82,6 +82,9 @@ export function renderToString$(cat, Component) {
   }
 
   return fetch$(fetchMap)
+    // move fetch to next event loop to prevent
+    // synchronous actions from causing infiniti loop
+    .delay(50)
     .map((fetchMap) => {
       const markup = renderToString(Burrito);
       return {
@@ -89,7 +92,6 @@ export function renderToString$(cat, Component) {
         fetchMap
       };
     })
-    .first()
     .tapOnNext(() => cat.fetchMap = null);
 }
 


### PR DESCRIPTION
If an action were to take place during a `componentWillMount`, this
will cause an infinite loop as the action triggers `combineLatest`
to emit an event, which then triggers another `renderToString`
which starts the whole thing over again.

There is a `first` filter in the stream, but internally the `onNext` of
the observer is called before the `onCompleted` of the observer can be
called, meaning the `first` filter never has a chance to call `onCompleted`

Moral of the story? Beware of Zalgo!
